### PR TITLE
neutrino+pushtx: make broadcast timeout configurable with fallback

### DIFF
--- a/pushtx/broadcaster.go
+++ b/pushtx/broadcaster.go
@@ -20,6 +20,10 @@ var (
 )
 
 const (
+	// DefaultBroadcastTimeout is the default timeout used when broadcasting
+	// transactions to network peers.
+	DefaultBroadcastTimeout = 5 * time.Second
+
 	// DefaultRebroadcastInterval is the default period that we'll wait
 	// between blocks to attempt another rebroadcast.
 	DefaultRebroadcastInterval = time.Minute

--- a/query.go
+++ b/query.go
@@ -4,11 +4,11 @@ package neutrino
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/wire"
@@ -1447,7 +1447,7 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 		// the other peer must query its own state to determine whether
 		// it should accept the transaction.
 		append(
-			[]QueryOption{Timeout(time.Millisecond * 500)},
+			[]QueryOption{Timeout(s.broadcastTimeout)},
 			options...,
 		)...,
 	)

--- a/rescan.go
+++ b/rescan.go
@@ -6,12 +6,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gcash/bchd/chaincfg"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/rpcclient"
 	"github.com/gcash/bchd/txscript"


### PR DESCRIPTION
From https://github.com/lightninglabs/neutrino/pull/220

```
This is useful for enabling shorter timeouts than we would use in a
production environment in testing environments, resulting in shorter
test execution times. If a timeout isn't provided, we'll use the default
of 5 seconds.
```