### PR TITLE
Add PersistToDisk property to ChainService

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -540,6 +540,12 @@ type Config struct {
 	// Proxy is an address to use to connect remote peers using the socks5 proxy.
 	Proxy string
 
+	// PersistToDisk indicates whether the filter should also be written
+	// to disk in addition to the memory cache. For "normal" wallets, they'll
+	// almost never need to re-match a filter once it's been fetched unless
+	// they're doing something like a key import.
+	PersistToDisk bool
+
 	// AssertFilterHeader is an optional field that allows the creator of
 	// the ChainService to ensure that if any chain data exists, it's
 	// compliant with the expected filter header state. If neutrino starts
@@ -570,6 +576,7 @@ type ChainService struct {
 	FilterDB         filterdb.FilterDatabase
 	BlockHeaders     headerfs.BlockHeaderStore
 	RegFilterHeaders *headerfs.FilterHeaderStore
+	persistToDisk    bool
 
 	FilterCache *lru.Cache
 	BlockCache  *lru.Cache
@@ -678,6 +685,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		blocksOnly:        cfg.BlocksOnly,
 		mempool:           NewMempool(),
 		proxy:             cfg.Proxy,
+		persistToDisk:     cfg.PersistToDisk,
 		broadcastTimeout:  cfg.BroadcastTimeout,
 	}
 

--- a/query.go
+++ b/query.go
@@ -106,12 +106,6 @@ type queryOptions struct {
 	// it's run in a goroutine.
 	doneChan chan<- struct{}
 
-	// persistToDisk indicates whether the filter should also be written
-	// to disk in addition to the memory cache. For "normal" wallets, they'll
-	// almost never need to re-match a filter once it's been fetched unless
-	// they're doing something like a key import.
-	persistToDisk bool
-
 	// invalidTxThreshold is the threshold for the fraction of peers
 	// that need to respond to a TX with a code of pushtx.Invalid to count
 	// it as invalid, even if not all peers respond. This option is only
@@ -228,14 +222,6 @@ func Encoding(encoding wire.MessageEncoding) QueryOption {
 func DoneChan(doneChan chan<- struct{}) QueryOption {
 	return func(qo *queryOptions) {
 		qo.doneChan = doneChan
-	}
-}
-
-// PersistToDisk allows the caller to tell that the filter should be kept
-// on disk once it's found.
-func PersistToDisk() QueryOption {
-	return func(qo *queryOptions) {
-		qo.persistToDisk = true
 	}
 }
 
@@ -1161,7 +1147,7 @@ func (s *ChainService) handleCFiltersResponse(q *cfiltersQuery,
 
 	qo := defaultQueryOptions()
 	qo.applyQueryOptions(q.options...)
-	if qo.persistToDisk {
+	if s.persistToDisk {
 		err = s.FilterDB.PutFilter(
 			&response.BlockHash, gotFilter, dbFilterType,
 		)


### PR DESCRIPTION
https://github.com/lightninglabs/neutrino/pull/194
```
Previously PersisToDisk is an option to GetCFilter.
The problem is that the option is not working well with the in-memory
FilterCache. The biggest problem is that if there are two calls of
GetCFilter, the first one without the PersistToDisk option, and the second
one with the PersistToDisk option, the second one returns the filter from
the cache and doesn't write it persistently to the disk.
Consequently, if a filter was already queried, there is no way to write it
to disk. So for instance if a neutrino user (mainly lnd) is closed before
it is fully synchronized, it need to re-download all the filters when it
runs again.
When handling the PersistToDisk in the ChainService itself, the caller of
NewChainService decides in _one place_ if the filters need to be stored
in the disk, and that will not depend on the order of calls to
GetCFilter.
```