### PR TITLE
absorb NeutrinoClient

### DIFF
--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package chain
 
 import (

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -1,0 +1,787 @@
+package chain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchlog"
+
+	neutrino "github.com/dcrlabs/neutrino-bch"
+	"github.com/gcash/bchd/chaincfg"
+	"github.com/gcash/bchd/chaincfg/chainhash"
+	"github.com/gcash/bchd/rpcclient"
+	"github.com/gcash/bchd/txscript"
+	"github.com/gcash/bchd/wire"
+	"github.com/gcash/bchutil"
+	"github.com/gcash/bchutil/gcs"
+	"github.com/gcash/bchutil/gcs/builder"
+	"github.com/gcash/bchwallet/chain"
+	"github.com/gcash/bchwallet/waddrmgr"
+	"github.com/gcash/bchwallet/wtxmgr"
+)
+
+// NeutrinoClient is an implementation of the bchwalet chain.Interface interface.
+type NeutrinoClient struct {
+	CS  *neutrino.ChainService
+	log bchlog.Logger
+
+	chainParams *chaincfg.Params
+
+	// We currently support one rescan/notifiction goroutine per client
+	rescan *neutrino.Rescan
+
+	enqueueNotification     chan interface{}
+	dequeueNotification     chan interface{}
+	startTime               time.Time
+	lastProgressSent        bool
+	lastFilteredBlockHeader *wire.BlockHeader
+	currentBlock            chan *waddrmgr.BlockStamp
+
+	quit       chan struct{}
+	rescanQuit chan struct{}
+	rescanErr  <-chan error
+	wg         sync.WaitGroup
+	started    bool
+	scanning   bool
+	finished   bool
+	isRescan   bool
+
+	clientMtx sync.Mutex
+}
+
+// NewNeutrinoClient creates a new NeutrinoClient struct with a backing
+// ChainService.
+func NewNeutrinoClient(chainParams *chaincfg.Params,
+	chainService *neutrino.ChainService, log bchlog.Logger) *NeutrinoClient {
+
+	return &NeutrinoClient{
+		CS:          chainService,
+		chainParams: chainParams,
+		log:         log,
+	}
+}
+
+// BackEnd returns the name of the driver.
+func (s *NeutrinoClient) BackEnd() string {
+	return "neutrino"
+}
+
+// Start replicates the RPC client's Start method.
+func (s *NeutrinoClient) Start() error {
+	s.CS.RegisterMempoolCallback(s.onRecvTx)
+	s.CS.Start()
+	s.clientMtx.Lock()
+	defer s.clientMtx.Unlock()
+	if !s.started {
+		s.enqueueNotification = make(chan interface{})
+		s.dequeueNotification = make(chan interface{})
+		s.currentBlock = make(chan *waddrmgr.BlockStamp)
+		s.quit = make(chan struct{})
+		s.started = true
+		s.wg.Add(1)
+		go func() {
+			select {
+			case s.enqueueNotification <- chain.ClientConnected{}:
+			case <-s.quit:
+			}
+		}()
+		go s.notificationHandler()
+	}
+	return nil
+}
+
+// Stop replicates the RPC client's Stop method.
+func (s *NeutrinoClient) Stop() {
+	s.clientMtx.Lock()
+	defer s.clientMtx.Unlock()
+	if !s.started {
+		return
+	}
+	close(s.quit)
+	s.started = false
+}
+
+// WaitForShutdown replicates the RPC client's WaitForShutdown method.
+func (s *NeutrinoClient) WaitForShutdown() {
+	s.wg.Wait()
+}
+
+// GetBlock replicates the RPC client's GetBlock command.
+func (s *NeutrinoClient) GetBlock(hash *chainhash.Hash) (*wire.MsgBlock, error) {
+	// TODO(roasbeef): add a block cache?
+	//  * which evication strategy? depends on use case
+	//  Should the block cache be INSIDE neutrino instead of in bchwallet?
+	block, err := s.CS.GetBlock(*hash)
+	if err != nil {
+		return nil, err
+	}
+	return block.MsgBlock(), nil
+}
+
+// GetBlockHeight gets the height of a block by its hash. It serves as a
+// replacement for the use of GetBlockVerboseTxAsync for the wallet package
+// since we can't actually return a FutureGetBlockVerboseResult because the
+// underlying type is private to rpcclient.
+func (s *NeutrinoClient) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
+	return s.CS.GetBlockHeight(hash)
+}
+
+// GetBestBlock replicates the RPC client's GetBestBlock command.
+func (s *NeutrinoClient) GetBestBlock() (*chainhash.Hash, int32, error) {
+	chainTip, err := s.CS.BestBlock()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return &chainTip.Hash, chainTip.Height, nil
+}
+
+// BlockStamp returns the latest block notified by the client, or an error
+// if the client has been shut down.
+func (s *NeutrinoClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
+	select {
+	case bs := <-s.currentBlock:
+		return bs, nil
+	case <-s.quit:
+		return nil, errors.New("disconnected")
+	}
+}
+
+// GetBlockHash returns the block hash for the given height, or an error if the
+// client has been shut down or the hash at the block height doesn't exist or
+// is unknown.
+func (s *NeutrinoClient) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	return s.CS.GetBlockHash(height)
+}
+
+// GetBlockHeader returns the block header for the given block hash, or an error
+// if the client has been shut down or the hash doesn't exist or is unknown.
+func (s *NeutrinoClient) GetBlockHeader(
+	blockHash *chainhash.Hash) (*wire.BlockHeader, error) {
+	return s.CS.GetBlockHeader(blockHash)
+}
+
+// IsCurrent returns whether the chain backend considers its view of the network
+// as "current".
+func (s *NeutrinoClient) IsCurrent() bool {
+	return s.CS.IsCurrent()
+}
+
+// SendRawTransaction replicates the RPC client's SendRawTransaction command.
+func (s *NeutrinoClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
+	*chainhash.Hash, error) {
+	err := s.CS.SendTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+	hash := tx.TxHash()
+	return &hash, nil
+}
+
+// FilterBlocks scans the blocks contained in the FilterBlocksRequest for any
+// addresses of interest. For each requested block, the corresponding compact
+// filter will first be checked for matches, skipping those that do not report
+// anything. If the filter returns a postive match, the full block will be
+// fetched and filtered. This method returns a FilterBlocksReponse for the first
+// block containing a matching address. If no matches are found in the range of
+// blocks requested, the returned response will be nil.
+func (s *NeutrinoClient) FilterBlocks(
+	req *chain.FilterBlocksRequest) (*chain.FilterBlocksResponse, error) {
+
+	blockFilterer := chain.NewBlockFilterer(s.chainParams, req)
+
+	// Construct the watchlist using the addresses and outpoints contained
+	// in the filter blocks request.
+	watchList, err := buildFilterBlocksWatchList(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over the requested blocks, fetching the compact filter for
+	// each one, and matching it against the watchlist generated above. If
+	// the filter returns a positive match, the full block is then requested
+	// and scanned for addresses using the block filterer.
+	for i, blk := range req.Blocks {
+		// TODO(wilmer): Investigate why polling it still necessary
+		// here. While testing, I ran into a few instances where the
+		// filter was not retrieved, leading to a panic. This should not
+		// happen in most cases thanks to the query logic revamp within
+		// Neutrino, but it seems there's still an uncovered edge case.
+		filter, err := s.pollCFilter(&blk.Hash)
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip any empty filters.
+		if filter == nil || filter.N() == 0 {
+			continue
+		}
+
+		key := builder.DeriveKey(&blk.Hash)
+		matched, err := filter.MatchAny(key, watchList)
+		if err != nil {
+			return nil, err
+		} else if !matched {
+			continue
+		}
+
+		s.log.Infof("Fetching block height=%d hash=%v",
+			blk.Height, blk.Hash)
+
+		// TODO(conner): can optimize bandwidth by only fetching
+		// stripped blocks
+		rawBlock, err := s.GetBlock(&blk.Hash)
+		if err != nil {
+			return nil, err
+		}
+
+		if !blockFilterer.FilterBlock(rawBlock) {
+			continue
+		}
+
+		// If any external or internal addresses were detected in this
+		// block, we return them to the caller so that the rescan
+		// windows can widened with subsequent addresses. The
+		// `BatchIndex` is returned so that the caller can compute the
+		// *next* block from which to begin again.
+		resp := &chain.FilterBlocksResponse{
+			BatchIndex:         uint32(i),
+			BlockMeta:          blk,
+			FoundExternalAddrs: blockFilterer.FoundExternal,
+			FoundInternalAddrs: blockFilterer.FoundInternal,
+			FoundOutPoints:     blockFilterer.FoundOutPoints,
+			RelevantTxns:       blockFilterer.RelevantTxns,
+		}
+
+		return resp, nil
+	}
+
+	// No addresses were found for this range.
+	return nil, nil
+}
+
+// buildFilterBlocksWatchList constructs a watchlist used for matching against a
+// cfilter from a FilterBlocksRequest. The watchlist will be populated with all
+// external addresses, internal addresses, and outpoints contained in the
+// request.
+func buildFilterBlocksWatchList(req *chain.FilterBlocksRequest) ([][]byte, error) {
+	// Construct a watch list containing the script addresses of all
+	// internal and external addresses that were requested, in addition to
+	// the set of outpoints currently being watched.
+	watchListSize := len(req.ExternalAddrs) +
+		len(req.InternalAddrs) +
+		(len(req.WatchedOutPoints) * 2)
+
+	watchList := make([][]byte, 0, watchListSize)
+
+	for _, addr := range req.ExternalAddrs {
+		p2shAddr, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		watchList = append(watchList, p2shAddr)
+	}
+
+	for _, addr := range req.InternalAddrs {
+		p2shAddr, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		watchList = append(watchList, p2shAddr)
+	}
+
+	for op, addr := range req.WatchedOutPoints {
+		addr, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		watchList = append(watchList, addr)
+
+		var buf bytes.Buffer
+		if err := op.Serialize(&buf); err != nil {
+			return nil, err
+		}
+
+		watchList = append(watchList, buf.Bytes())
+	}
+
+	return watchList, nil
+}
+
+// pollCFilter attempts to fetch a CFilter from the neutrino client. This is
+// used to get around the fact that the filter headers may lag behind the
+// highest known block header.
+func (s *NeutrinoClient) pollCFilter(hash *chainhash.Hash) (*gcs.Filter, error) {
+	var (
+		filter *gcs.Filter
+		err    error
+		count  int
+	)
+
+	const maxFilterRetries = 50
+	for count < maxFilterRetries {
+		if count > 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		filter, err = s.CS.GetCFilter(
+			*hash, wire.GCSFilterRegular, neutrino.OptimisticBatch(),
+		)
+		if err != nil {
+			count++
+			continue
+		}
+
+		return filter, nil
+	}
+
+	return nil, err
+}
+
+// Rescan replicates the RPC client's Rescan command.
+func (s *NeutrinoClient) Rescan(startHash *chainhash.Hash, addrs []bchutil.Address,
+	outPoints map[wire.OutPoint]bchutil.Address) error {
+
+	s.clientMtx.Lock()
+
+	s.CS.NotifyMempoolReceived(addrs)
+
+	if !s.started {
+		s.clientMtx.Unlock()
+		return fmt.Errorf("can't do a rescan when the chain client " +
+			"is not started")
+	}
+	if s.scanning {
+		// Restart the rescan by killing the existing rescan.
+		close(s.rescanQuit)
+		rescan := s.rescan
+		s.clientMtx.Unlock()
+		rescan.WaitForShutdown()
+		s.clientMtx.Lock()
+		s.rescan = nil
+		s.rescanErr = nil
+	}
+	s.rescanQuit = make(chan struct{})
+	s.scanning = true
+	s.finished = false
+	s.lastProgressSent = false
+	s.lastFilteredBlockHeader = nil
+	s.isRescan = true
+	s.clientMtx.Unlock()
+
+	bestBlock, err := s.CS.BestBlock()
+	if err != nil {
+		return fmt.Errorf("Can't get chain service's best block: %s", err)
+	}
+	header, err := s.CS.GetBlockHeader(&bestBlock.Hash)
+	if err != nil {
+		return fmt.Errorf("Can't get block header for hash %v: %s",
+			bestBlock.Hash, err)
+	}
+
+	// If the wallet is already fully caught up, or the rescan has started
+	// with state that indicates a "fresh" wallet, we'll send a
+	// notification indicating the rescan has "finished".
+	if header.BlockHash() == *startHash {
+		s.clientMtx.Lock()
+		s.finished = true
+		rescanQuit := s.rescanQuit
+		s.clientMtx.Unlock()
+
+		// Release the lock while dispatching the notification since
+		// it's possible for the notificationHandler to be waiting to
+		// acquire it before receiving the notification.
+		select {
+		case s.enqueueNotification <- &chain.RescanFinished{
+			Hash:   startHash,
+			Height: bestBlock.Height,
+			Time:   header.Timestamp,
+		}:
+		case <-s.quit:
+			return nil
+		case <-rescanQuit:
+			return nil
+		}
+	}
+
+	var inputsToWatch []neutrino.InputWithScript
+	for op, addr := range outPoints {
+		addrScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return err
+		}
+
+		inputsToWatch = append(inputsToWatch, neutrino.InputWithScript{
+			OutPoint: op,
+			PkScript: addrScript,
+		})
+	}
+
+	s.clientMtx.Lock()
+	newRescan := neutrino.NewRescan(
+		&neutrino.RescanChainSource{
+			ChainService: s.CS,
+		},
+		neutrino.NotificationHandlers(rpcclient.NotificationHandlers{
+			OnClientConnected:        nil,
+			OnBlockConnected:         s.onBlockConnected,
+			OnFilteredBlockConnected: s.onFilteredBlockConnected,
+			OnBlockDisconnected:      s.onBlockDisconnected,
+		}),
+		neutrino.StartBlock(&waddrmgr.BlockStamp{Hash: *startHash}),
+		neutrino.StartTime(s.startTime),
+		neutrino.QuitChan(s.rescanQuit),
+		neutrino.WatchAddrs(addrs...),
+		neutrino.WatchInputs(inputsToWatch...),
+	)
+	s.rescan = newRescan
+	s.rescanErr = s.rescan.Start()
+	s.clientMtx.Unlock()
+
+	return nil
+}
+
+// NotifyBlocks replicates the RPC client's NotifyBlocks command.
+func (s *NeutrinoClient) NotifyBlocks() error {
+	s.clientMtx.Lock()
+	// If we're scanning, we're already notifying on blocks. Otherwise,
+	// start a rescan without watching any addresses.
+	if !s.scanning {
+		s.clientMtx.Unlock()
+		return s.NotifyReceived([]bchutil.Address{})
+	}
+	s.clientMtx.Unlock()
+	return nil
+}
+
+// NotifyReceived replicates the RPC client's NotifyReceived command.
+func (s *NeutrinoClient) NotifyReceived(addrs []bchutil.Address) error {
+	s.clientMtx.Lock()
+
+	s.CS.NotifyMempoolReceived(addrs)
+
+	// If we have a rescan running, we just need to add the appropriate
+	// addresses to the watch list.
+	if s.scanning {
+		s.clientMtx.Unlock()
+		return s.rescan.Update(neutrino.AddAddrs(addrs...))
+	}
+
+	s.rescanQuit = make(chan struct{})
+	s.scanning = true
+
+	// Don't need RescanFinished or RescanProgress notifications.
+	s.finished = true
+	s.lastProgressSent = true
+	s.lastFilteredBlockHeader = nil
+
+	// Rescan with just the specified addresses.
+	newRescan := neutrino.NewRescan(
+		&neutrino.RescanChainSource{
+			ChainService: s.CS,
+		},
+		neutrino.NotificationHandlers(rpcclient.NotificationHandlers{
+			OnBlockConnected:         s.onBlockConnected,
+			OnFilteredBlockConnected: s.onFilteredBlockConnected,
+			OnBlockDisconnected:      s.onBlockDisconnected,
+		}),
+		neutrino.StartTime(s.startTime),
+		neutrino.QuitChan(s.rescanQuit),
+		neutrino.WatchAddrs(addrs...),
+	)
+	s.rescan = newRescan
+	s.rescanErr = s.rescan.Start()
+	s.clientMtx.Unlock()
+	return nil
+}
+
+// Notifications replicates the RPC client's Notifications method.
+func (s *NeutrinoClient) Notifications() <-chan interface{} {
+	return s.dequeueNotification
+}
+
+// SetStartTime is a non-interface method to set the birthday of the wallet
+// using this object. Since only a single rescan at a time is currently
+// supported, only one birthday needs to be set. This does not fully restart a
+// running rescan, so should not be used to update a rescan while it is running.
+// TODO: When factoring out to multiple rescans per Neutrino client, add a
+// birthday per client.
+func (s *NeutrinoClient) SetStartTime(startTime time.Time) {
+	s.clientMtx.Lock()
+	defer s.clientMtx.Unlock()
+
+	s.startTime = startTime
+}
+
+// onFilteredBlockConnected sends appropriate notifications to the notification
+// channel.
+func (s *NeutrinoClient) onFilteredBlockConnected(height int32,
+	header *wire.BlockHeader, relevantTxs []*bchutil.Tx) {
+	ntfn := chain.FilteredBlockConnected{
+		Block: &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{
+				Hash:   header.BlockHash(),
+				Height: height,
+			},
+			Time: header.Timestamp,
+		},
+	}
+	for _, tx := range relevantTxs {
+		rec, err := wtxmgr.NewTxRecordFromMsgTx(tx.MsgTx(),
+			header.Timestamp)
+		if err != nil {
+			s.log.Errorf("Cannot create transaction record for "+
+				"relevant tx: %v", err)
+			// TODO(aakselrod): Return?
+			continue
+		}
+		ntfn.RelevantTxs = append(ntfn.RelevantTxs, rec)
+	}
+
+	select {
+	case s.enqueueNotification <- ntfn:
+	case <-s.quit:
+		return
+	case <-s.rescanQuit:
+		return
+	}
+
+	s.clientMtx.Lock()
+	s.lastFilteredBlockHeader = header
+	s.clientMtx.Unlock()
+
+	// Handle RescanFinished notification if required.
+	s.dispatchRescanFinished()
+}
+
+// onBlockDisconnected sends appropriate notifications to the notification
+// channel.
+func (s *NeutrinoClient) onBlockDisconnected(hash *chainhash.Hash, height int32,
+	t time.Time) {
+	select {
+	case s.enqueueNotification <- chain.BlockDisconnected{
+		Block: wtxmgr.Block{
+			Hash:   *hash,
+			Height: height,
+		},
+		Time: t,
+	}:
+	case <-s.quit:
+	case <-s.rescanQuit:
+	}
+}
+
+func (s *NeutrinoClient) onBlockConnected(hash *chainhash.Hash, height int32,
+	time time.Time) {
+	// TODO: Move this closure out and parameterize it? Is it useful
+	// outside here?
+	sendRescanProgress := func() {
+		select {
+		case s.enqueueNotification <- &chain.RescanProgress{
+			Hash:   hash,
+			Height: height,
+			Time:   time,
+		}:
+		case <-s.quit:
+		case <-s.rescanQuit:
+		}
+	}
+	// Only send BlockConnected notification if we're processing blocks
+	// before the birthday. Otherwise, we can just update using
+	// RescanProgress notifications.
+	if time.Before(s.startTime) {
+		// Send a RescanProgress notification every 1K blocks.
+		if height%1000 == 0 {
+			s.clientMtx.Lock()
+			shouldSend := s.isRescan && !s.finished
+			s.clientMtx.Unlock()
+			if shouldSend {
+				sendRescanProgress()
+			}
+		}
+	} else {
+		// Send a RescanProgress notification if we're just going over
+		// the boundary between pre-birthday and post-birthday blocks,
+		// and note that we've sent it.
+		s.clientMtx.Lock()
+		if !s.lastProgressSent {
+			shouldSend := s.isRescan && !s.finished
+			if shouldSend {
+				s.clientMtx.Unlock()
+				sendRescanProgress()
+				s.clientMtx.Lock()
+				s.lastProgressSent = true
+			}
+		}
+		s.clientMtx.Unlock()
+		select {
+		case s.enqueueNotification <- chain.BlockConnected{
+			Block: wtxmgr.Block{
+				Hash:   *hash,
+				Height: height,
+			},
+			Time: time,
+		}:
+		case <-s.quit:
+		case <-s.rescanQuit:
+		}
+	}
+
+	// Check if we're able to dispatch our final RescanFinished notification
+	// after processing this block.
+	s.dispatchRescanFinished()
+}
+
+// dispatchRescanFinished determines whether we're able to dispatch our final
+// RescanFinished notification in order to mark the wallet as synced with the
+// chain. If the notification has already been dispatched, then it won't be done
+// again.
+func (s *NeutrinoClient) dispatchRescanFinished() {
+	bs, err := s.CS.BestBlock()
+	if err != nil {
+		s.log.Errorf("Can't get chain service's best block: %s", err)
+		return
+	}
+
+	s.clientMtx.Lock()
+	// Only send the RescanFinished notification once.
+	if s.lastFilteredBlockHeader == nil || s.finished {
+		s.clientMtx.Unlock()
+		return
+	}
+
+	// Only send the RescanFinished notification once the underlying chain
+	// service sees itself as current.
+	if bs.Hash != s.lastFilteredBlockHeader.BlockHash() {
+		s.clientMtx.Unlock()
+		return
+	}
+
+	s.finished = s.CS.IsCurrent() && s.lastProgressSent
+	if !s.finished {
+		s.clientMtx.Unlock()
+		return
+	}
+
+	header := s.lastFilteredBlockHeader
+	s.clientMtx.Unlock()
+
+	select {
+	case s.enqueueNotification <- &chain.RescanFinished{
+		Hash:   &bs.Hash,
+		Height: bs.Height,
+		Time:   header.Timestamp,
+	}:
+	case <-s.quit:
+		return
+	case <-s.rescanQuit:
+		return
+	}
+}
+
+// notificationHandler queues and dequeues notifications. There are currently
+// no bounds on the queue, so the dequeue channel should be read continually to
+// avoid running out of memory.
+func (s *NeutrinoClient) notificationHandler() {
+	hash, height, err := s.GetBestBlock()
+	if err != nil {
+		s.log.Errorf("Failed to get best block from chain service: %s",
+			err)
+		s.Stop()
+		s.wg.Done()
+		return
+	}
+
+	bs := &waddrmgr.BlockStamp{Hash: *hash, Height: height}
+
+	// TODO: Rather than leaving this as an unbounded queue for all types of
+	// notifications, try dropping ones where a later enqueued notification
+	// can fully invalidate one waiting to be processed.  For example,
+	// blockconnected notifications for greater block heights can remove the
+	// need to process earlier blockconnected notifications still waiting
+	// here.
+
+	var notifications []interface{}
+	enqueue := s.enqueueNotification
+	var dequeue chan interface{}
+	var next interface{}
+out:
+	for {
+		s.clientMtx.Lock()
+		rescanErr := s.rescanErr
+		s.clientMtx.Unlock()
+		select {
+		case n, ok := <-enqueue:
+			if !ok {
+				// If no notifications are queued for handling,
+				// the queue is finished.
+				if len(notifications) == 0 {
+					break out
+				}
+				// nil channel so no more reads can occur.
+				enqueue = nil
+				continue
+			}
+			if len(notifications) == 0 {
+				next = n
+				dequeue = s.dequeueNotification
+			}
+			notifications = append(notifications, n)
+
+		case dequeue <- next:
+			if n, ok := next.(chain.BlockConnected); ok {
+				bs = &waddrmgr.BlockStamp{
+					Height: n.Height,
+					Hash:   n.Hash,
+				}
+			}
+
+			notifications[0] = nil
+			notifications = notifications[1:]
+			if len(notifications) != 0 {
+				next = notifications[0]
+			} else {
+				// If no more notifications can be enqueued, the
+				// queue is finished.
+				if enqueue == nil {
+					break out
+				}
+				dequeue = nil
+			}
+
+		case err := <-rescanErr:
+			if err != nil {
+				s.log.Errorf("Neutrino rescan ended with error: %v", err)
+			}
+
+		case s.currentBlock <- bs:
+
+		case <-s.quit:
+			break out
+		}
+	}
+
+	s.Stop()
+	close(s.dequeueNotification)
+	s.wg.Done()
+}
+
+func (s *NeutrinoClient) onRecvTx(tx *bchutil.Tx, block *btcjson.BlockDetails) {
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx.MsgTx(), time.Now())
+	if err != nil {
+		s.log.Errorf("Cannot create transaction record for relevant "+
+			"tx: %v", err)
+		return
+	}
+	select {
+	case s.enqueueNotification <- chain.RelevantTx{TxRecord: rec}:
+	case <-s.quit:
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/btcsuite/golangcrypto v0.0.0-20150304025918-53f62d9b43e8 // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/dchest/siphash v1.2.2 // indirect
+	github.com/gcash/neutrino v0.0.0-20210524105223-4cec86bbd8a4 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
+	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/zquestz/grab v0.0.0-20190224022517-abcee96e61b1 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ github.com/gcash/bchwallet/walletdb v0.0.0-20210524044131-61bcca2ae6f9 h1:lryOGJ
 github.com/gcash/bchwallet/walletdb v0.0.0-20210524044131-61bcca2ae6f9/go.mod h1:KNPI56t8uMlItrGyu3tS4NCd3jGfA6KjdUg4bsk+QJg=
 github.com/gcash/neutrino v0.0.0-20210524024247-f7bf0435d155/go.mod h1:91zIrel7tOt35+0hAN8Rrr7O07LZrR9b98Nk4AcC/Lg=
 github.com/gcash/neutrino v0.0.0-20210524083541-2900eef48821/go.mod h1:ud/wsgR459Qy+HmEAoQZF9XPTYaOYep5df8ynowCnLs=
+github.com/gcash/neutrino v0.0.0-20210524105223-4cec86bbd8a4 h1:CFXcaAlSkzKSsXph7WIhQBtQqxqUVSqOT2ixW+lia5I=
 github.com/gcash/neutrino v0.0.0-20210524105223-4cec86bbd8a4/go.mod h1:YBR6T+ZT02eR1S7JGqJ2gVPxZlfjWswTCXB4HZafp/U=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -481,6 +482,7 @@ github.com/letsencrypt/pkcs11key/v4 v4.0.0/go.mod h1:EFUvBDay26dErnNb70Nd0/VW3tJ
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=


### PR DESCRIPTION
bchwallet's `chain.NeutrinoClient` implements `chain.Interface`, but relies on `gcash/neutrino` types, which we're taking getting rid of. This fixes the problem.